### PR TITLE
fix: Correct copyright headers of files forked from TVL

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,13 @@
-# Copyright (c) 2020 Geoffrey Huntley <ghuntley@ghuntley.com>. All rights reserved.
-# SPDX-License-Identifier: Proprietary
-
-# This file sets up the top-level package set by traversing the package tree
-# (see read-tree.nix for details) and constructing a matching attribute set
-# tree.
+# Copyright (c) 2019-2021 The TVL Authors
+# SPDX-License-Identifier: MIT
 #
-# This makes packages accessible via the Nixery instance that is configured to
-# use this repository as its nixpkgs source.
-
+# This file sets up the top-level package set by traversing the
+# package tree using readTree[0] and constructing a matching attribute
+# set tree.
+#
+# [0]: https://code.tvl.fyi/about/nix/readTree
+#
+# Forked from https://code.tvl.fyi/tree/default.nix?id=f59ab9aba506c1ed149f7093f5543ef021567ebc
 { ... }@args:
 
 with builtins;

--- a/ops/ci/default.nix
+++ b/ops/ci/default.nix
@@ -1,12 +1,14 @@
-# Copyright (c) 2020 Geoffrey Huntley <ghuntley@ghuntley.com>. All rights reserved.
-# SPDX-License-Identifier: Proprietary
-
+# Copyright (c) 2019-2021 The TVL Authors
+# SPDX-License-Identifier: MIT
+#
 # This file configures the primary build pipeline used for the
 # top-level list of depot targets.
 #
 # It outputs a "YAML" (actually JSON) file which is evaluated and
 # submitted to Buildkite at the start of each build. This means we can
 # dynamically configure the pipeline execution here.
+#
+# Forked from https://code.tvl.fyi/tree/ops/pipelines/depot.nix?id=9c482d6238cccbe038b11e71468ee73edd124309
 { depot, lib, pkgs, ... }:
 let
   inherit (builtins) concatStringsSep foldl' map toJSON;

--- a/tools/hash-password.nix
+++ b/tools/hash-password.nix
@@ -1,5 +1,5 @@
-# Copyright (c) 2020 Geoffrey Huntley <ghuntley@ghuntley.com>. All rights reserved.
-# SPDX-License-Identifier: Proprietary
+# Copyright (c) 2019-2021 The TVL Authors
+# SPDX-License-Identifier: MIT
 
 # Utility for invoking slappasswd with the correct options for
 # creating an ARGON2 password hash.

--- a/tools/perf-flamegraph.nix
+++ b/tools/perf-flamegraph.nix
@@ -1,5 +1,5 @@
-# Copyright (c) 2020 Geoffrey Huntley <ghuntley@ghuntley.com>. All rights reserved.
-# SPDX-License-Identifier: Proprietary
+# Copyright (c) 2019-2021 The TVL Authors
+# SPDX-License-Identifier: MIT
 
 # Script that collects perf timing for the execution of a command and writes a
 # flamegraph to stdout


### PR DESCRIPTION
This fixes the copyright headers of files that were forked from the
TVL depot and not modified substantially enough to warrant
relicensing.

Note that there's also some code under //third_party which is from TVL
and doesn't include the copyright notes required by TVL, but I didn't
touch those in this commit.

This commit is exempt from CLA as it only modifies files to which we
hold the copyright.